### PR TITLE
Make all tests not verbose by default

### DIFF
--- a/tests/testthat/setup-verbose_minimization.R
+++ b/tests/testthat/setup-verbose_minimization.R
@@ -1,0 +1,1 @@
+verbose_minimization <- FALSE

--- a/tests/testthat/test-model01.R
+++ b/tests/testthat/test-model01.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME01: one-compartment bolus, single-dose")
@@ -24,7 +25,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -77,9 +78,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model02.R
+++ b/tests/testthat/test-model02.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME02: one-compartment bolus, multiple-dose")
     test_that("Closed-form", {
@@ -23,7 +25,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -76,9 +78,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model03.R
+++ b/tests/testthat/test-model03.R
@@ -1,6 +1,7 @@
 library(testthat)
 library(nlmixr)
 library(reshape2)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME03: one-compartment bolus, steady-state")
@@ -66,7 +67,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -160,9 +161,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model04.R
+++ b/tests/testthat/test-model04.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME04: one-compartment bolus, multiple-dose")
     test_that("Closed-form", {
@@ -23,7 +25,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -76,9 +78,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model09.R
+++ b/tests/testthat/test-model09.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME09: one-compartment bolus, Michaelis-Menten, single-dose")
@@ -38,9 +39,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
                 par_trans = mypar3,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fit)

--- a/tests/testthat/test-model10.R
+++ b/tests/testthat/test-model10.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME10: one-compartment bolus, Michaelis-Menten, multiple-dose")
@@ -38,9 +39,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
                 par_trans = mypar3,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fit)

--- a/tests/testthat/test-model11.R
+++ b/tests/testthat/test-model11.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME11: one-compartment bolus, Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -37,9 +39,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
                 par_trans = mypar3,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fit)

--- a/tests/testthat/test-model12.R
+++ b/tests/testthat/test-model12.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME12: one-compartment infusion, single-dose")
     test_that("Closed-form", {
@@ -36,7 +38,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1))
@@ -102,9 +104,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model13.R
+++ b/tests/testthat/test-model13.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME13: one-compartment infusion, multiple-dose")
@@ -37,7 +38,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1))
@@ -103,9 +104,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model14.R
+++ b/tests/testthat/test-model14.R
@@ -1,6 +1,8 @@
 library(testthat)
 library(nlmixr)
 library(reshape2)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME14: one-compartment infusion, steady state")
     test_that("Closed-form", {
@@ -63,7 +65,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1))
@@ -155,9 +157,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model15.R
+++ b/tests/testthat/test-model15.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME15: one-compartment infusion, multiple-dose")
@@ -36,7 +37,7 @@ rxPermissive({
                 dat,
                 par_model = specs1,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1))
@@ -101,9 +102,9 @@ rxPermissive({
                 par_trans = mypar1,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- summary(fitODE)

--- a/tests/testthat/test-model20.R
+++ b/tests/testthat/test-model20.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME20: one-compartment infusion, single-dose, Michaelis-Menten")
@@ -49,9 +50,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
             par_trans = mypar3,
             response = "centr",
             response.scaler = "V",
-            verbose = TRUE,
+            verbose = verbose_minimization,
             weight = varPower(fixed = c(1)),
-            control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+            control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
         )
 
     z <- VarCorr(fit)

--- a/tests/testthat/test-model21.R
+++ b/tests/testthat/test-model21.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME21: one-compartment infusion, multiple-dose, Michaelis-Menten")
     test_that("ODE", {
@@ -47,9 +49,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
             par_trans = mypar3,
             response = "centr",
             response.scaler = "V",
-            verbose = TRUE,
+            verbose = verbose_minimization,
             weight = varPower(fixed = c(1)),
-            control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+            control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
         )
 
     z <- VarCorr(fit)

--- a/tests/testthat/test-model22.R
+++ b/tests/testthat/test-model22.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME22: one-compartment infusion, multiple-dose, Michaelis-Menten")
@@ -48,9 +49,9 @@ d/dt(centr)  = -(VM*centr/V)/(KM+centr/V);
             par_trans = mypar3,
             response = "centr",
             response.scaler = "V",
-            verbose = TRUE,
+            verbose = verbose_minimization,
             weight = varPower(fixed = c(1)),
-            control = nlmeControl(pnlsTol = .01, msVerbose = TRUE)
+            control = nlmeControl(pnlsTol = .01, msVerbose = verbose_minimization)
         )
 
     z <- VarCorr(fit)

--- a/tests/testthat/test-model23.R
+++ b/tests/testthat/test-model23.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME23: one-compartment oral, single-dose")
     test_that("Closed-form", {
@@ -36,7 +38,7 @@ rxPermissive({
                 dat,
                 par_model = specs4,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1))
             )
@@ -94,12 +96,12 @@ rxPermissive({
                 par_trans = mypar4,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
                 control = nlmeControl(
                     pnlsTol = .3,
                     tolerance = 1e-3,
-                    msVerbose = TRUE
+                    msVerbose = verbose_minimization
                 )
             )
 

--- a/tests/testthat/test-model24.R
+++ b/tests/testthat/test-model24.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME24: one-compartment oral, multiple-dose")
@@ -37,7 +38,7 @@ rxPermissive({
                 dat,
                 par_model = specs4i,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1))
             )
@@ -95,9 +96,9 @@ rxPermissive({
                 par_trans = mypar4,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model25.R
+++ b/tests/testthat/test-model25.R
@@ -1,6 +1,7 @@
 library(testthat)
 library(nlmixr)
 library(reshape2)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME25: one-compartment oral, multiple-dose")
@@ -70,7 +71,7 @@ rxPermissive({
                 dat,
                 par_model = specs4,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1))
             )
@@ -160,9 +161,9 @@ rxPermissive({
                 par_trans = mypar4,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model26.R
+++ b/tests/testthat/test-model26.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME26: one-compartment oral, multiple-dose")
@@ -37,7 +38,7 @@ rxPermissive({
                 dat,
                 par_model = specs4i,
                 ncmt = 1,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1))
             )
@@ -96,9 +97,9 @@ rxPermissive({
                 par_trans = mypar4,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .2, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .2, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model29.R
+++ b/tests/testthat/test-model29.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME29: one-compartment oral, Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -47,9 +49,9 @@ rxPermissive({
                 par_trans = mypar5,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model30.R
+++ b/tests/testthat/test-model30.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME30: one-compartment oral, Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -48,9 +50,9 @@ rxPermissive({
                 par_trans = mypar5,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model31.R
+++ b/tests/testthat/test-model31.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME31: one-compartment oral, Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -49,9 +51,9 @@ rxPermissive({
                 par_trans = mypar5,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model32.R
+++ b/tests/testthat/test-model32.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME32: two-compartment bolus, single-dose")
     test_that("Closed-form", {
@@ -47,7 +49,7 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1)),
                 control=nlmeControl(pnlsTol=0.01)
@@ -117,9 +119,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model33.R
+++ b/tests/testthat/test-model33.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME33: two-compartment bolus, multiple-dose")
     test_that("Closed-form", {
@@ -46,7 +48,7 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -116,9 +118,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = 0.3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model34.R
+++ b/tests/testthat/test-model34.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME34: two-compartment bolus, steady-state")
     test_that("Closed-form", {
@@ -75,7 +77,7 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -173,9 +175,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model35.R
+++ b/tests/testthat/test-model35.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME35: two-compartment oral, multiple-dose")
     test_that("Closed-form", {
@@ -46,7 +48,7 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 weight = varPower(fixed = c(1))
             )
@@ -115,9 +117,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = 0.3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model40.R
+++ b/tests/testthat/test-model40.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME40: two-compartment bolus Michaelis-Menten, single-dose")
     test_that("ODE", {
@@ -48,9 +50,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model41.R
+++ b/tests/testthat/test-model41.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME41: two-compartment bolus Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -48,9 +50,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model42.R
+++ b/tests/testthat/test-model42.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME42: two-compartment bolus Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -48,9 +50,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model46.R
+++ b/tests/testthat/test-model46.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME46: two-compartment infusion, single-dose")
     test_that("Closed-form", {
@@ -40,13 +42,13 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1)),
                 control = nlmeControl(
                     pnlsTol = .1,
-                    msVerbose = TRUE,
+                    msVerbose = verbose_minimization,
                     maxIter = 200
                 )
             )
@@ -127,9 +129,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model47.R
+++ b/tests/testthat/test-model47.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME47: two-compartment infusion, multiple-dose")
     test_that("Closed-form", {
@@ -40,13 +42,13 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1)),
                 control = nlmeControl(
                     pnlsTol = .1,
-                    msVerbose = TRUE,
+                    msVerbose = verbose_minimization,
                     maxIter = 200
                 )
             )
@@ -127,9 +129,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model48.R
+++ b/tests/testthat/test-model48.R
@@ -1,6 +1,7 @@
 library(testthat)
 library(nlmixr)
 library(reshape2)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME48: two-compartment infusion, steady-state")
@@ -69,13 +70,13 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1)),
                 control = nlmeControl(
                     pnlsTol = .1,
-                    msVerbose = TRUE,
+                    msVerbose = verbose_minimization,
                     maxIter = 200
                 )
             )
@@ -182,9 +183,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model49.R
+++ b/tests/testthat/test-model49.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME49: two-compartment infusion, multiple-dose")
@@ -41,13 +42,13 @@ rxPermissive({
                 dat,
                 par_model = specs6,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = FALSE,
                 infusion = TRUE,
                 weight = varPower(fixed = c(1)),
                 control = nlmeControl(
                     pnlsTol = .1,
-                    msVerbose = TRUE,
+                    msVerbose = verbose_minimization,
                     maxIter = 200
                 )
             )
@@ -128,9 +129,9 @@ rxPermissive({
                 par_trans = mypar6,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model54.R
+++ b/tests/testthat/test-model54.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME54: two-compartment infusion Michaelis-Menten, single-dose")
@@ -60,9 +61,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model55.R
+++ b/tests/testthat/test-model55.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME55: two-compartment infusion Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -59,9 +61,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model56.R
+++ b/tests/testthat/test-model56.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME56: two-compartment infusion Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -58,9 +60,9 @@ rxPermissive({
                 par_trans = mypar7,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model60.R
+++ b/tests/testthat/test-model60.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME60: two-compartment oral, single-dose")
     test_that("Closed-form", {
@@ -51,10 +53,10 @@ rxPermissive({
                 dat,
                 par_model = specs8,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)
@@ -130,9 +132,9 @@ rxPermissive({
                 par_trans = mypar8,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model61.R
+++ b/tests/testthat/test-model61.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME61: two-compartment oral, multiple-dose")
     test_that("Closed-form", {
@@ -51,10 +53,10 @@ rxPermissive({
                 dat,
                 par_model = specs8,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)
@@ -129,9 +131,9 @@ rxPermissive({
                 par_trans = mypar8,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model62.R
+++ b/tests/testthat/test-model62.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME62: two-compartment oral, steady-state, multiple-dose")
@@ -63,10 +64,10 @@ rxPermissive({
                 dat,
                 par_model = specs8i,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .15, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .15, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)
@@ -170,9 +171,9 @@ rxPermissive({
                 par_trans = mypar8,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .15, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .15, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model63.R
+++ b/tests/testthat/test-model63.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME63: two-compartment oral, multiple-dose")
 
@@ -52,10 +54,10 @@ rxPermissive({
                 dat,
                 par_model = specs8,
                 ncmt = 2,
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 oral = TRUE,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)
@@ -134,9 +136,9 @@ rxPermissive({
                 par_trans = mypar8,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .3, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .3, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fitODE)

--- a/tests/testthat/test-model68.R
+++ b/tests/testthat/test-model68.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME68: two-compartment oral Michaelis-Menten, single-dose")
     test_that("ODE", {
@@ -58,9 +60,9 @@ rxPermissive({
             par_trans = mypar9,
             response = "centr",
             response.scaler = "V",
-            verbose = TRUE,
+            verbose = verbose_minimization,
             weight = varPower(fixed = c(1)),
-            control = nlmeControl(pnlsTol = .08, msVerbose = TRUE, msMaxIter=1000)
+            control = nlmeControl(pnlsTol = .08, msVerbose = verbose_minimization, msMaxIter=1000)
           )
 
         z <- VarCorr(fit)
@@ -99,9 +101,9 @@ rxPermissive({
                 par_trans = mypar9,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE, msMaxIter=1000)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization, msMaxIter=1000)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model69.R
+++ b/tests/testthat/test-model69.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
+
 rxPermissive({
     context("NLME69: two-compartment oral Michaelis-Menten, multiple-dose")
     test_that("ODE", {
@@ -55,9 +57,9 @@ rxPermissive({
                 par_trans = mypar9,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)

--- a/tests/testthat/test-model70.R
+++ b/tests/testthat/test-model70.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(nlmixr)
+if (!exists("verbose_minimization")) verbose_minimization <- FALSE
 
 rxPermissive({
     context("NLME70: two-compartment oral Michaelis-Menten, multiple-dose")
@@ -57,9 +58,9 @@ rxPermissive({
                 par_trans = mypar9,
                 response = "centr",
                 response.scaler = "V",
-                verbose = TRUE,
+                verbose = verbose_minimization,
                 weight = varPower(fixed = c(1)),
-                control = nlmeControl(pnlsTol = .1, msVerbose = TRUE)
+                control = nlmeControl(pnlsTol = .1, msVerbose = verbose_minimization)
             )
 
         z <- VarCorr(fit)


### PR DESCRIPTION
Make all `verbose` and `msVerbose` `FALSE` by default.  The `setup-verbose_minimization.R` allows for this to be more customized in the future.

(As mentioned in #99)