### PR TITLE
move #include <stan/math/prim/mat/fun/Eigen.hpp>

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Authors@R: c(person("Matthew","Fidler",
       email="wdenney@humanpredictions.com",
       comment=c(ORCID="0000-0002-5759-428X")),
    person("Daniel C.", "Dillon", role="ctb"),
-   person("Katharine","Mullen",role = "cph")
+   person("Katharine","Mullen",role = "cph"),
+   person("Ben", "Goodrich", role = "ctb")
    )
 Description: Fit and compare nonlinear mixed-effects models in differential
     equations with flexible dosing information commonly seen in pharmacokinetics

--- a/src/ode_cmt1.cpp
+++ b/src/ode_cmt1.cpp
@@ -1,3 +1,4 @@
+#include <stan/math/prim/mat/fun/Eigen.hpp> // must come before #include <RcppEigen.h>
 #include "../inst/include/nlmixr_types.h"
 #include <RcppEigen.h>
 // [[Rcpp::depends(RcppEigen)]]
@@ -5,7 +6,6 @@ using namespace Rcpp;
 
 #include <vector>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math.hpp>
 #include "PKPDLib_WW.h"
 


### PR DESCRIPTION
The nlmixr R package will fail with the next version of StanHeaders due to a useful but somewhat incompatible change introduced in Stan Math 2.20 that uses the Eigen plugin mechanism to hold adjoints along with the double values in `Eigen::Matrix<T, -1, -1>`. According to the Eigen [documentation](http://eigen.tuxfamily.org/dox/TopicCustomizing_Plugins.html) such plugins have to be `#include`d before any other Eigen headers. The nlmixr R package `#includes` it after `#include <RcppEigen.h>` which in turn `#includes` all the other Eigen headers, leading to compilation errors.

The fix in this is PR is trivial and passes R CMD check both with the CRAN and soon-to-be CRAN StanHeaders. If you need to test with the soon-to-be CRAN StanHeaders, you can do
```
source("https://raw.githubusercontent.com/stan-dev/rstan/for_2.20/StanHeaders/install-github.R")
install_StanHeaders(math_branch = "StanHeaders_2.21",
                    library_branch = "StanHeaders_2.21")
```
There is also an unrelated NOTE when doing R CMD check on due to man/foceiControl.Rd referring to http://apmonitor.com/me575/uploads/Main/optimization_book.pdf which seems to be a dead URL.

Please upload another version of nlmixr to CRAN ASAP so that I can upload StanHeaders early this week and have it pass the reverse dependency checks automatically. Also, @wds15 is facing a hard deadline Friday to get updated versions of official Stan-related things onto the server at Novartis.

AFTER the soon-to-be CRAN is released, you may want to put `RcppParallel` in the `LinkingTo` and making the corresponding changes to your Makevars file (basically adding `-DSTAN_THREADS` to the compiler flags and `RcppParallel::LdFlags()` to the linker flags). However, the TBB library packaged by RcppParallel and used by Stan Math 3.0 when `STAN_THREADS` is defined is Apache licensed, which is deemed to be incompatible with GPL-2 by the FSF. The FSF considers the Apache license to be compatible with GPL-3, so making nlmixr GPL-3 or GPL-3+ would allow it to take advantage of these speed ups.
