### PR TITLE
Fix evaluation environment in `update()` method

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -514,7 +514,7 @@ model <- function(model, ..., .lines=NULL){
         }
       } else if (is.name(.x)){
         .cur  <- 1;
-        .tmp <- eval(.x, sys.parent(1))
+        .tmp <- eval(.x, parent.frame())
         if (is(.tmp,"list") || is(.tmp,"numeric") || is(.tmp,"integer")){
           .uif <- eval(bquote(ini(.(.uif), .(.tmp))))
         } else {


### PR DESCRIPTION
Hello, I'm working on the next release of magrittr which will feature a C implementation. I see this problem in our revdep checks: https://github.com/tidyverse/magrittr/blob/master/revdep/full/problems.md#nlmixr

```
  > test_check("nlmixr")
  ── 1. Error: UI updates work correctly (@test-piping.R#63)  ────────────────────
  object '.tmp' not found
  Backtrace:
   1. f %>% update(tka = 4, cl = exp(tcl), ka = exp(tka), .tmp)
   3. nlmixr:::update.nlmixrUI(...)
```

The problem comes from using `sys.parent()` in the `update()` method. Unlike `parent.frame()`, `sys.parent()` does not always point to a caller environment, for example when evaluating from C within a data mask. It should mostly be avoided in package code.