### PR TITLE
Add compatibility with future RStan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -95,7 +95,8 @@ Description: Fit and compare nonlinear mixed-effects models in differential
 License: GPL (>=2)
 NeedsCompilation: yes
 LinkingTo: dparser(>= 0.1.8), RxODE(>= 1.0.0-0), RcppEigen (>= 0.3.3.3.0),
-    lbfgsb3c, Rcpp, BH, StanHeaders(>= 2.18.0), RcppArmadillo (>= 0.5.600.2.0)
+    lbfgsb3c, Rcpp, BH, StanHeaders(>= 2.18.0), RcppArmadillo (>= 0.5.600.2.0),
+    RcppParallel (>= 5.0.1)
 URL: https://github.com/nlmixrdevelopment/nlmixr
 LazyData: true
 RoxygenNote: 7.1.1

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -4,12 +4,13 @@ BH=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("BH"),"i
 RCPP=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("Rcpp"),"include"))'`
 EG=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppEigen"),"include"))'`
 SH=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("StanHeaders"),"include"))'`
+RPAR=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppParallel"),"include"))'`
 
 CXX_STD     = CXX14
 @CXX14STD@
 
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
-PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(SH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)"  $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(SH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -@ISYSTEM@"$(RPAR)"  $(SHLIB_OPENMP_CXXFLAGS)
 SHLIB_LDFLAGS = $(SHLIB_CXXLDFLAGS) 
 SHLIB_LD = $(SHLIB_CXXLD)
 SOURCES_C = init.c rprintf.c merge3.c lbfgsR.c utilc.c

--- a/src/PKPDLib_WW.h
+++ b/src/PKPDLib_WW.h
@@ -4,7 +4,11 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#if __has_include(<stan/math/prim/err/check_greater_or_equal.hpp>)
+#  include <stan/math/prim/err/check_greater_or_equal.hpp>
+#else
+#  include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#endif
 #include <vector>
 #include <utility>
 #include <cmath>


### PR DESCRIPTION
Hi,

This PR adds the changes needed for compatibility with the upcoming version of RStan.

Note that the some of the StanHeaders files will change location in the next version, so I've added an `__has_include()` conditional to ` src/PKPDLib_WW.h` to account for this.

Thanks!
Andrew