### PR TITLE
Add cxxflags for updated StanHeaders and fix portability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Depends: R (>= 4.0)
 Imports: Rcpp (>= 0.12.3), brew, parallel, lbfgsb3c,
         dparser, methods, ggplot2, rex, minqa, Matrix,
  	n1qn1 (>= 6.0.1-10), fastGHQuad,
-	RxODE(>= 1.0.6), nlme, magrittr, backports, symengine
+	RxODE(>= 1.0.6), nlme, magrittr, backports, symengine,
+    RcppParallel
 Suggests: 
     Deriv,
     Rvmmin,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,7 @@ Depends: R (>= 4.0)
 Imports: Rcpp (>= 0.12.3), brew, parallel, lbfgsb3c,
         dparser, methods, ggplot2, rex, minqa, Matrix,
  	n1qn1 (>= 6.0.1-10), fastGHQuad,
-	RxODE(>= 1.0.6), nlme, magrittr, backports, symengine,
-    RcppParallel
+	RxODE(>= 1.0.6), nlme, magrittr, backports, symengine
 Suggests: 
     Deriv,
     Rvmmin,

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,7 +6,8 @@ EG=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppEig
 SH=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("StanHeaders"),"include"))'`
 RPAR=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppParallel"),"include"))'`
 RPAR_LIBS=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()"`
-SH_LIBS=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()"`
+# Strip single quotes due to OSX build error
+SH_LIBS=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(gsub(\"\'\",\"\",capture.output(StanHeaders:::LdFlags())))"`
 RPAR_CXX=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()"`
 SH_CXX=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()"`
 CXX_STD     = CXX14

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -5,12 +5,15 @@ RCPP=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("Rcpp"
 EG=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppEigen"),"include"))'`
 SH=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("StanHeaders"),"include"))'`
 RPAR=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e 'cat(file.path(find.package("RcppParallel"),"include"))'`
-
+RPAR_LIBS=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()"`
+SH_LIBS=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()"`
+RPAR_CXX=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()"`
+SH_CXX=`"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()"`
 CXX_STD     = CXX14
 @CXX14STD@
 
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
-PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(SH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -@ISYSTEM@"$(RPAR)"  $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(RPAR_LIBS) $(SH_LIBS)
+PKG_CXXFLAGS = -Id -I../inst/include -DBOOST_DISABLE_ASSERTS -DBOOST_NO_CXX11_STATIC_ASSERT -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" -@ISYSTEM@"$(SH)" -@ISYSTEM@"$(RCPP)" -@ISYSTEM@"$(ARMA)" -@ISYSTEM@"$(RPAR)"  $(SHLIB_OPENMP_CXXFLAGS) $(RPAR_CXX) $(SH_CXX)
 SHLIB_LDFLAGS = $(SHLIB_CXXLDFLAGS) 
 SHLIB_LD = $(SHLIB_CXXLD)
 SOURCES_C = init.c rprintf.c merge3.c lbfgsR.c utilc.c


### PR DESCRIPTION
Hi All,

There are some additional compiler flags from StanHeaders and RcppParallel that will be needed once 2.26 hits CRAN. This PR adds those flags and also fixes the R CMD CHECK portability error introduced by the last pull.

Thanks!
Andrew