### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/saem.cpp
+++ b/src/saem.cpp
@@ -742,8 +742,7 @@ public:
 	vec d1_mu_phi1=Md1(ind_cov1);                              //CHK!! vec or mat
 	vec d1_mu_phi0=Md0(ind_cov0);                              //CHK!! vec or mat
 	vec d1_loggamma2_phi1=0.5*sdg1-0.5*N;
-	vec d1_logsigma2;
-	d1_logsigma2 << 0.5*resy(k)/sigma2[0]-0.5*ntotal;          //FIXME: sigma2[0], sigma2[b] instead?
+	vec d1_logsigma2({0.5*resy(k)/sigma2[0]-0.5*ntotal});      //FIXME: sigma2[0], sigma2[b] instead?
 	vec d1logk=join_cols(d1_mu_phi1, join_cols(d1_mu_phi0, join_cols(d1_loggamma2_phi1, d1_logsigma2)));
 	D1 = D1+d1logk;
 	D11= D11+d1logk*d1logk.t();


### PR DESCRIPTION
One simple one-line change to update RcppArmadillo use from the now  deprecated `<<` initialization to brace initialization allowed since C++11 and long been the minimal standard with R too.  It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391